### PR TITLE
Enable instantiating FalsificationProblems for non-Simulink BreachSystem

### DIFF
--- a/src/MABSingleFP.m
+++ b/src/MABSingleFP.m
@@ -24,7 +24,9 @@ classdef MABSingleFP < FalsificationProblem
         
         function this = MABSingleFP(BrSet, phi, cons, s, mI)
             this = this@FalsificationProblem(BrSet, phi);
-            this.cp = BrSet.InputGenerator.signalGenerators{1,1}.num_cp(1);
+            if isa(BrSet, 'BreachSimulinkSystem')
+                this.cp = BrSet.InputGenerator.signalGenerators{1,1}.num_cp(1);
+            end
             this.constraints  = cons;
             this.cons_size = numel(cons);
             this.variables = BrSet.GetSysVariables();

--- a/src/PFPINF2.m
+++ b/src/PFPINF2.m
@@ -27,7 +27,9 @@ classdef PFPINF2 < FalsificationProblem
         
         function this = PFPINF2(BrSet, phi, cons, S)
             this = this@FalsificationProblem(BrSet, phi);
-            this.cp = BrSet.InputGenerator.signalGenerators{1,1}.num_cp(1);
+            if isa(BrSet, 'BreachSimulinkSystem')
+                this.cp = BrSet.InputGenerator.signalGenerators{1,1}.num_cp(1);
+            end
             this.constraints  = cons;
             this.cons_size = numel(cons);
             this.variables = BrSet.GetSysVariables();

--- a/src/PracticalFP_Single.m
+++ b/src/PracticalFP_Single.m
@@ -28,7 +28,9 @@ classdef PracticalFP_Single < FalsificationProblem
         
         function this = PracticalFP_Single(BrSet, phi, cons, s)
             this = this@FalsificationProblem(BrSet, phi);
-            this.cp = BrSet.InputGenerator.signalGenerators{1,1}.num_cp(1);
+            if isa(BrSet, 'BreachSimulinkSystem')
+                this.cp = BrSet.InputGenerator.signalGenerators{1,1}.num_cp(1);
+            end
             this.constraints  = cons;
             this.cons_size = numel(cons);
             this.variables = BrSet.GetSysVariables();


### PR DESCRIPTION
I attempted to run PracticalFP_Single for a BreachSystem of a non-Simulink simulator (see [breach/Interfacing a generic simulator](https://github.com/decyphir/breach/?tab=readme-ov-file#interfacing-a-generic-simulator)) but failed to instantiate the PracticalFP_Single object. This PR is meant to address this issue.